### PR TITLE
[FIX] mail_composer_cc_bcc: send RFQ by email

### DIFF
--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -12,6 +12,8 @@ class MailThread(models.AbstractModel):
     def _message_create(self, values_list):
         context = self.env.context
         res = super()._message_create(values_list)
+        if res.message_type == "notification":
+            return res
         partners_cc = context.get("partner_cc_ids", None)
         if partners_cc:
             res.recipient_cc_ids = partners_cc
@@ -48,7 +50,7 @@ class MailThread(models.AbstractModel):
         rdata = super()._notify_get_recipients(message, msg_vals, **kwargs)
         context = self.env.context
         is_from_composer = context.get("is_from_composer", False)
-        if not is_from_composer:
+        if not is_from_composer or msg_vals.get("message_type") == "notification":
             return rdata
         for pdata in rdata:
             pdata["type"] = "customer"


### PR DESCRIPTION
* Context
  - when we send a RFQ by email, a notification message is also created to track change of state from RFQ to RFQ Sent
  - avoid sending an email for that notification

* This change
  - Check message_type: if notification, avoid sending



**Before**

![Screenshot from 2024-02-06 16-57-19](https://github.com/trisdoan/social/assets/88806544/681f78f1-8cbd-4685-b408-ee21fe54eb50)


**After**

![Screenshot from 2024-02-06 16-43-08](https://github.com/trisdoan/social/assets/88806544/a958f332-296e-4f54-bfeb-2a56716483d7)
