### PR TITLE
[TMP] XP

### DIFF
--- a/mail_composer_cc_bcc/models/ir_mail_server.py
+++ b/mail_composer_cc_bcc/models/ir_mail_server.py
@@ -3,51 +3,21 @@
 
 from odoo import models
 
-from .mail_thread import format_emails
-
 
 class IrMailServer(models.Model):
     _inherit = "ir.mail_server"
 
-    def build_email(
-        self,
-        email_from,
-        email_to,
-        subject,
-        body,
-        email_cc=None,
-        email_bcc=None,
-        reply_to=False,
-        attachments=None,
-        message_id=None,
-        references=None,
-        object_id=False,
-        subtype="plain",
-        headers=None,
-        body_alternative=None,
-        subtype_alternative="plain",
-    ):
-        context = self.env.context
-
-        res = super().build_email(
-            email_from,
-            email_to,
-            subject,
-            body,
-            email_cc=email_cc,
-            email_bcc=email_bcc,
-            reply_to=reply_to,
-            attachments=attachments,
-            message_id=message_id,
-            references=references,
-            object_id=object_id,
-            subtype=subtype,
-            headers=headers,
-            body_alternative=body_alternative,
-            subtype_alternative=subtype_alternative,
+    def _prepare_email_message(self, message, smtp_session):
+        """
+        Define smtp_to based on context instead of To+Cc+Bcc
+        """
+        smtp_from, smtp_to_list, message = super()._prepare_email_message(
+            message, smtp_session
         )
 
-        if context.get("partner_bcc_ids"):
-            res["Bcc"] = format_emails(context.get("partner_bcc_ids"))
+        is_from_composer = self.env.context.get("is_from_composer", False)
+        if is_from_composer and self.env.context.get("recipients", False):
+            smtp_to = self.env.context["recipients"].pop(0)
+            smtp_to_list = [smtp_to]
 
-        return res
+        return smtp_from, smtp_to_list, message


### PR DESCRIPTION
- tried a different approach:
  - roll back to do as odoo: one mail per recipient
  - keep same all headers (To, Cc, Bcc) in all emails (headers are just used for display in the email clients)
  - but use a context trick to define the proper smtp_to for each email

- pros: allows to have a custom mail body per recipient (for the tracking)
- cons: slower, as we send more mails

thoughts welcome!