### PR TITLE
[17.0] oca-port: store 'email_template_qweb' data

### DIFF
--- a/.oca/oca-port/blacklist/email_template_qweb.json
+++ b/.oca/oca-port/blacklist/email_template_qweb.json
@@ -1,0 +1,3 @@
+{
+  "no_migration": "included in standard"
+}


### PR DESCRIPTION
### Context
After this [commit](https://github.com/odoo/odoo/commit/4813f429976a609513aa992a9813956165403872), Jinja was replaced with qweb.

- Introduced a new rendering engine, `inline_template` to support dynamic variables such as email_to =>  will render an expression enclosed by `{{` and `}}`.
- So, Odoo has 3 rendering engines: inline_template, qweb (Render a raw QWeb template) or qweb_view (Render a QWeb template based on an ir.ui.view content)

**=> No need to port this module from 17.0+**


**Interesting related features**

From 18.0+
- With this [commit](https://github.com/odoo/odoo/commit/6c4526ec3b9509e0a6b99503d8d888417b2695e0), mail composer will now display a dropdown menu for the mail templates, user can easily load, overwrite or delete a template.
- With this [commit](https://github.com/odoo/odoo/commit/505a5ca54f8f4e204352b69d4388786c20933181), user can use simple expressions im mail template

![qwebpicker](https://github.com/user-attachments/assets/1a2ade90-695d-4b10-8995-ce481e599cb5)


From 17.0+
- With this [commit](https://github.com/odoo/odoo/commit/3d5b0125012fecd3ee2611d140d454dd7b9d9f43), rendering API provides 2 options to the rendering process: preserve_comments, post_process (used notably to process local links and add tracking to shortened links)
- With this [commit](https://github.com/odoo/odoo/commit/39dd2fc2abbe1401b690e8544edc443c137bbea1), each user can have their own templates that they can edit and save
