### PR TITLE
[16.0][FIX] mail_composer_cc_bcc: fix duplicate key value error "unique_mail_message_id_res_partner_id_if_set"

### DIFF
--- a/mail_composer_cc_bcc/README.rst
+++ b/mail_composer_cc_bcc/README.rst
@@ -106,6 +106,7 @@ Contributors
 
     * Hai N. Le <hailn@trobz.com>
     * Son Ho <sonhd@trobz.com>
+    * Tris Doan <tridm@trobz.com>
 
 * `Therp BV <https://therp.nl>`_:
 

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -62,9 +62,13 @@ class MailThread(models.AbstractModel):
         recipients_cc_bcc = MailFollowers._get_recipient_data(
             None, message_type, subtype_id, partners_cc_bcc.ids
         )
+        partners_already_marked_as_recipient = [r.get("id", False) for r in rdata]
         for _, value in recipients_cc_bcc.items():
             for _, data in value.items():
-                if not data.get("id"):
+                if (
+                    not data.get("id")
+                    or data.get("id") in partners_already_marked_as_recipient
+                ):
                     continue
                 if not data.get(
                     "notif"

--- a/mail_composer_cc_bcc/readme/CONTRIBUTORS.rst
+++ b/mail_composer_cc_bcc/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 
     * Hai N. Le <hailn@trobz.com>
     * Son Ho <sonhd@trobz.com>
+    * Tris Doan <tridm@trobz.com>
 
 * `Therp BV <https://therp.nl>`_:
 

--- a/mail_composer_cc_bcc/static/description/index.html
+++ b/mail_composer_cc_bcc/static/description/index.html
@@ -452,6 +452,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Hai N. Le &lt;<a class="reference external" href="mailto:hailn&#64;trobz.com">hailn&#64;trobz.com</a>&gt;</li>
 <li>Son Ho &lt;<a class="reference external" href="mailto:sonhd&#64;trobz.com">sonhd&#64;trobz.com</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </blockquote>
 </li>

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -85,8 +85,8 @@ class TestMailCcBcc(TestMailComposer):
         # Company default values
         env.company.default_partner_cc_ids = self.partner_cc3
         env.company.default_partner_bcc_ids = self.partner_cc2
-        # Product template values
-        tmpl_model = env["ir.model"].search([("model", "=", "product.template")])
+        # Partner template values
+        tmpl_model = env["ir.model"].search([("model", "=", "res.partner")])
         partner_cc = self.partner_cc
         partner_bcc = self.partner_bcc
         vals = {
@@ -102,18 +102,18 @@ Test Template<br></p>""",
                 (partner_bcc.name or "False", partner_bcc.email or "False")
             ),
         }
-        prod_tmpl = env["mail.template"].create(vals)
+        partner_tmpl = env["mail.template"].create(vals)
         # Open mail composer form and check for default values from company
         form = self.open_mail_composer_form()
         composer = form.save()
         self.assertEqual(composer.partner_cc_ids, self.partner_cc3)
         self.assertEqual(composer.partner_bcc_ids, self.partner_cc2)
         # Change email template and check for values from it
-        form.template_id = prod_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         # Beside existing Cc and Bcc, add template's ones
         form = Form(composer)
-        form.template_id = prod_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)
@@ -127,8 +127,8 @@ Test Template<br></p>""",
         form = Form(composer)
         form.template_id = env["mail.template"]
         form.save()
-        self.assertFalse(form.template_id)
-        form.template_id = prod_tmpl
+        self.assertFalse(form.template_id)  # no template
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)


### PR DESCRIPTION
### Note
- Took over this PR:
- Backport from `17.0`: using `res.partner `instead `product.template` in test. Otherwise, tests cannot run because model product.template is not in environment.