### PR TITLE
[17.0][FIX] mail_composer_cc_bcc: fix duplicate key value error "unique_mail_message_id_res_partner_id_if_set"

### DIFF
--- a/mail_composer_cc_bcc/README.rst
+++ b/mail_composer_cc_bcc/README.rst
@@ -35,11 +35,12 @@ confusing for a lot of end users.
 This module allows to properly separate To:, Cc:, and Bcc: fields in the
 Mail Composer.
 
+From Odoo 17.0, this module sends one mail per recipient and keeps same
+all headers (To, Cc, Bcc) in all emails
+
 Features
 --------
 
--  Add Cc and Bcc fields to mail composer form. Send only once to
-   multiple email addresses.
 -  Add Cc and Bcc fields to company form to use them as default in mail
    composer form.
 -  Add Bcc field to mail template form. Use Cc and Bcc fields to lookup
@@ -86,12 +87,6 @@ corresponding mail composer's fields.
 
 .. |image| image:: https://raw.githubusercontent.com/OCA/social/17.0/mail_composer_cc_bcc/static/img/mail_compose_message_default_cc_bcc.png
 .. |image1| image:: https://raw.githubusercontent.com/OCA/social/17.0/mail_composer_cc_bcc/static/img/mail_compose_message_template_cc_bcc.png
-
-Known issues / Roadmap
-======================
-
--  Extract account customization (account.invoice.send wizard) to a
-   specific module mail_composer_cc_bcc_account
 
 Bug Tracker
 ===========

--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -44,7 +44,7 @@ class MailMail(models.Model):
 
         # Collect recipients (RCPT TO) and update all emails
         # with the same To, Cc headers (to be shown by email client as users expect)
-        recipients = []
+        recipients = set()
         for m in res:
             rcpt_to = None
             if m["email_to"]:
@@ -64,7 +64,7 @@ class MailMail(models.Model):
                 rcpt_to = extract_rfc2822_addresses(m["email_cc"][0])[0]
 
             if rcpt_to:
-                recipients.append(rcpt_to)
+                recipients.add(rcpt_to)
 
             m.update(
                 {
@@ -74,5 +74,9 @@ class MailMail(models.Model):
                 }
             )
 
-        self.env.context = {**self.env.context, "recipients": recipients}
+        self.env.context = {**self.env.context, "recipients": list(recipients)}
+
+        if len(res) > len(recipients):
+            res.pop()
+
         return res

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -69,9 +69,13 @@ class MailThread(models.AbstractModel):
         recipients_cc_bcc = MailFollowers._get_recipient_data(
             None, message_type, subtype_id, partners_cc_bcc.ids
         )
+        partners_already_marked_as_recipient = [r.get("id", False) for r in rdata]
         for _, value in recipients_cc_bcc.items():
             for _, data in value.items():
-                if not data.get("id"):
+                if (
+                    not data.get("id")
+                    or data.get("id") in partners_already_marked_as_recipient
+                ):
                     continue
                 if not data.get(
                     "notif"

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -34,6 +34,9 @@ class MailThread(models.AbstractModel):
             message, additional_values=additional_values
         )
         context = self.env.context
+        skip_adding_cc_bcc = context.get("skip_adding_cc_bcc", False)
+        if skip_adding_cc_bcc:
+            return res
 
         partners_cc = context.get("partner_cc_ids", None)
         if partners_cc:
@@ -55,7 +58,8 @@ class MailThread(models.AbstractModel):
         rdata = super()._notify_get_recipients(message, msg_vals, **kwargs)
         context = self.env.context
         is_from_composer = context.get("is_from_composer", False)
-        if not is_from_composer:
+        skip_adding_cc_bcc = context.get("skip_adding_cc_bcc", False)
+        if not is_from_composer or skip_adding_cc_bcc:
             return rdata
         for pdata in rdata:
             pdata["type"] = "customer"
@@ -100,7 +104,8 @@ class MailThread(models.AbstractModel):
             message, recipients_data, model_description, msg_vals=msg_vals
         )
         is_from_composer = self.env.context.get("is_from_composer", False)
-        if not is_from_composer:
+        skip_adding_cc_bcc = self.env.context.get("skip_adding_cc_bcc", False)
+        if not is_from_composer or skip_adding_cc_bcc:
             return res
         ids = []
         customer_data = None
@@ -116,3 +121,8 @@ class MailThread(models.AbstractModel):
         else:
             customer_data["recipients"] += ids
         return [customer_data]
+
+    def _notify_thread(self, message, msg_vals=False, **kwargs):
+        if message.message_type == "notification":
+            self = self.with_context(skip_adding_cc_bcc=True)
+        return super()._notify_thread(message, msg_vals, **kwargs)

--- a/mail_composer_cc_bcc/readme/DESCRIPTION.md
+++ b/mail_composer_cc_bcc/readme/DESCRIPTION.md
@@ -5,10 +5,10 @@ confusing for a lot of end users.
 This module allows to properly separate To:, Cc:, and Bcc: fields in the
 Mail Composer.
 
+From Odoo 17.0, this module sends one mail per recipient and keeps same all headers (To, Cc, Bcc) in all emails
+
 ## Features
 
-- Add Cc and Bcc fields to mail composer form. Send only once to
-  multiple email addresses.
 - Add Cc and Bcc fields to company form to use them as default in mail
   composer form.
 - Add Bcc field to mail template form. Use Cc and Bcc fields to lookup

--- a/mail_composer_cc_bcc/readme/ROADMAP.md
+++ b/mail_composer_cc_bcc/readme/ROADMAP.md
@@ -1,2 +1,0 @@
-- Extract account customization (account.invoice.send wizard) to a
-  specific module mail_composer_cc_bcc_account

--- a/mail_composer_cc_bcc/static/description/index.html
+++ b/mail_composer_cc_bcc/static/description/index.html
@@ -375,11 +375,11 @@ default; instead, it only has a unique Recipients fields, which is
 confusing for a lot of end users.</p>
 <p>This module allows to properly separate To:, Cc:, and Bcc: fields in the
 Mail Composer.</p>
+<p>From Odoo 17.0, this module sends one mail per recipient and keeps same
+all headers (To, Cc, Bcc) in all emails</p>
 <div class="section" id="features">
 <h1>Features</h1>
 <ul class="simple">
-<li>Add Cc and Bcc fields to mail composer form. Send only once to
-multiple email addresses.</li>
 <li>Add Cc and Bcc fields to company form to use them as default in mail
 composer form.</li>
 <li>Add Bcc field to mail template form. Use Cc and Bcc fields to lookup
@@ -397,9 +397,8 @@ Only for development or testing purpose, do not use in production.
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a></li>
 </ul>
 </div>
 <div class="section" id="configuration">
@@ -423,15 +422,8 @@ corresponding mail composer’s fields.</p>
 <blockquote>
 <img alt="image1" src="https://raw.githubusercontent.com/OCA/social/17.0/mail_composer_cc_bcc/static/img/mail_compose_message_template_cc_bcc.png" /></blockquote>
 </div>
-<div class="section" id="known-issues-roadmap">
-<h2><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h2>
-<ul class="simple">
-<li>Extract account customization (account.invoice.send wizard) to a
-specific module mail_composer_cc_bcc_account</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/social/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -439,7 +431,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-5">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-4">Credits</a></h2>
 </div>
 </div>
 <div class="section" id="authors">

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -64,6 +64,7 @@ class TestMailCcBcc(TestMailComposerForm):
         self.assertIn(func_hash, VALID_HASHES.get("mail.composer:_compute_partner_ids"))
 
     def test_email_cc_bcc(self):
+        self.test_record.email = "test@example.com"
         form = self.open_mail_composer_form()
         composer = form.save()
         # Use object to update Many2many fields (form can't do like this)
@@ -75,8 +76,14 @@ class TestMailCcBcc(TestMailComposerForm):
         with self.mock_mail_gateway():
             composer._action_send_mail()
 
+        self.assertEqual(len(self._mails), 5)
+
         # Verify recipients of mail.message
         message = self.test_record.message_ids[0]
+
+        # only keep 1 email to avoid clutting db
+        # but actually send 1 mail per recipients
+        self.assertEqual(len(message.mail_ids), 1)
         self.assertEqual(len(message.recipient_cc_ids), 3)
         self.assertEqual(len(message.recipient_bcc_ids), 1)
         # Verify notification


### PR DESCRIPTION
### Note
- Port from:  https://github.com/trisdoan/social/pull/28

### This changes
- Took this occasion to
   - Avoid duplicated mail, it was due to these lines from standard
https://github.com/odoo/odoo/blob/3e18fd8c4ddd304c8378ec5f546121d5a0814f38/addons/mail/models/mail_mail.py#L443-L452
     - To fix it, I added an comparison between number of mails and number of recipients

   - Enrich DESCRIPTION.md
     - As part of Migration to 17.0, we agreed that this module rolled back to the way Odoo works: send 1 mail per recipients
     - For example, sending an quotation mail with
       - 1 main recipient("To")
       - 1 cc mail
       - 1 bcc mail
=> there are 3 outgoing mails with same headers, but db only stores 1 mail