### PR TITLE
[16.0][FIX] mail_composer_cc_bcc: fix duplicate key value error "unique_mail_message_id_res_partner_id_if_set"

### DIFF
--- a/mail_composer_cc_bcc/README.rst
+++ b/mail_composer_cc_bcc/README.rst
@@ -106,6 +106,7 @@ Contributors
 
     * Hai N. Le <hailn@trobz.com>
     * Son Ho <sonhd@trobz.com>
+    * Tris Doan <tridm@trobz.com>
 
 * `Therp BV <https://therp.nl>`_:
 

--- a/mail_composer_cc_bcc/models/mail_thread.py
+++ b/mail_composer_cc_bcc/models/mail_thread.py
@@ -62,9 +62,13 @@ class MailThread(models.AbstractModel):
         recipients_cc_bcc = MailFollowers._get_recipient_data(
             None, message_type, subtype_id, partners_cc_bcc.ids
         )
+        partners_already_marked_as_recipient = [r.get("id", False) for r in rdata]
         for _, value in recipients_cc_bcc.items():
             for _, data in value.items():
-                if not data.get("id"):
+                if (
+                    not data.get("id")
+                    or data.get("id") in partners_already_marked_as_recipient
+                ):
                     continue
                 if not data.get(
                     "notif"

--- a/mail_composer_cc_bcc/readme/CONTRIBUTORS.rst
+++ b/mail_composer_cc_bcc/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 
     * Hai N. Le <hailn@trobz.com>
     * Son Ho <sonhd@trobz.com>
+    * Tris Doan <tridm@trobz.com>
 
 * `Therp BV <https://therp.nl>`_:
 

--- a/mail_composer_cc_bcc/static/description/index.html
+++ b/mail_composer_cc_bcc/static/description/index.html
@@ -452,6 +452,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Hai N. Le &lt;<a class="reference external" href="mailto:hailn&#64;trobz.com">hailn&#64;trobz.com</a>&gt;</li>
 <li>Son Ho &lt;<a class="reference external" href="mailto:sonhd&#64;trobz.com">sonhd&#64;trobz.com</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </blockquote>
 </li>

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -5,9 +5,11 @@ import hashlib
 import inspect
 
 from odoo import tools
-from odoo.tests import Form
+from odoo.tests import Form, tagged
+from odoo.tests.common import TransactionCase
 
 from odoo.addons.mail.models.mail_mail import MailMail as upstream
+from odoo.addons.mail.tests.common import MailCase
 from odoo.addons.mail.tests.test_mail_composer import TestMailComposer
 
 VALID_HASHES = ["d52cb36b88b33abc9556f7be6718d93f", "461467cd5b356072fc054468c75f6e26"]
@@ -175,3 +177,81 @@ Test Template<br></p>""",
             if subject == mail.get("subject"):
                 sent_mails += 1
         self.assertEqual(sent_mails, 1)
+
+
+@tagged("-at_install", "post_install")
+class TestMailComposerCcBccWithTracking(TransactionCase, MailCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.partner = cls.env.ref("base.res_partner_address_31")
+        cls.partner_cc = cls.env.ref("base.partner_demo")
+        cls.partner_bcc = cls.env.ref("base.res_partner_main2")
+        cls.admin_user = cls.env.ref("base.user_admin")
+
+        if "purchase.order" in cls.env:
+            cls.new_po = (
+                cls.env["purchase.order"]
+                .create(
+                    {
+                        "partner_id": cls.partner.id,
+                    }
+                )
+                .with_context(mail_notrack=False)
+            )
+
+    def test_tracking_mail_without_cc_bcc(self):
+        if self.new_po:
+            self.cr.precommit.clear()
+            # create a PO
+            # user subscribe to tracking status of PO
+            self.new_po.message_subscribe(
+                partner_ids=self.admin_user.partner_id.ids,
+                subtype_ids=(
+                    (
+                        self.env.ref("purchase.mt_rfq_sent")
+                        | self.env.ref("purchase.mt_rfq_confirmed")
+                    ).ids
+                ),
+            )
+
+            composer_ctx = self.new_po.action_rfq_send()
+            # send RFQ with cc/bcc
+            form = Form(
+                self.env["mail.compose.message"].with_context(**composer_ctx["context"])
+            )
+            composer = form.save()
+            composer.partner_ids = self.partner
+            composer.partner_cc_ids = self.partner_cc
+            composer.partner_bcc_ids = self.partner_bcc
+
+            with self.mock_mail_gateway(), self.mock_mail_app():
+                composer._action_send_mail()
+                self.flush_tracking()
+            self.assertEqual(
+                len(self._new_msgs),
+                2,
+                "Expected a tracking message and a RFQ message",
+            )
+            self.assertEqual(
+                self.ref("purchase.mt_rfq_sent"),
+                self._new_msgs[1].subtype_id.id,
+                "Expected a tracking message",
+            )
+
+            # RFQ email should include cc/bcc
+            rfq_message = self._new_msgs.filtered(lambda x: x.message_type == "comment")
+            self.assertEqual(len(rfq_message.notified_partner_ids), 3)
+            self.assertEqual(len(rfq_message.notification_ids), 3)
+            rfq_mail = rfq_message.mail_ids
+            self.assertEqual(len(rfq_mail.recipient_ids), 3)
+
+            # tracking email should not include cc/bcc
+            tracking_message = self._new_msgs.filtered(
+                lambda x: x.message_type == "notification"
+            )
+            tracking_field_mail = tracking_message.mail_ids
+            self.assertEqual(len(tracking_field_mail.recipient_ids), 1)
+            self.assertEqual(
+                tracking_field_mail.recipient_ids, self.admin_user.partner_id
+            )

--- a/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
+++ b/mail_composer_cc_bcc/tests/test_mail_cc_bcc.py
@@ -85,12 +85,12 @@ class TestMailCcBcc(TestMailComposer):
         # Company default values
         env.company.default_partner_cc_ids = self.partner_cc3
         env.company.default_partner_bcc_ids = self.partner_cc2
-        # Product template values
-        tmpl_model = env["ir.model"].search([("model", "=", "product.template")])
+        # Partner template values
+        tmpl_model = env["ir.model"].search([("model", "=", "res.partner")])
         partner_cc = self.partner_cc
         partner_bcc = self.partner_bcc
         vals = {
-            "name": "Product Template: Re: [E-COM11] Cabinet with Doors",
+            "name": "Test Template",
             "model_id": tmpl_model.id,
             "subject": "Re: [E-COM11] Cabinet with Doors",
             "body_html": """<p style="margin:0px 0 12px 0;box-sizing:border-box;">
@@ -102,18 +102,18 @@ Test Template<br></p>""",
                 (partner_bcc.name or "False", partner_bcc.email or "False")
             ),
         }
-        prod_tmpl = env["mail.template"].create(vals)
+        partner_tmpl = env["mail.template"].create(vals)
         # Open mail composer form and check for default values from company
         form = self.open_mail_composer_form()
         composer = form.save()
         self.assertEqual(composer.partner_cc_ids, self.partner_cc3)
         self.assertEqual(composer.partner_bcc_ids, self.partner_cc2)
         # Change email template and check for values from it
-        form.template_id = prod_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         # Beside existing Cc and Bcc, add template's ones
         form = Form(composer)
-        form.template_id = prod_tmpl
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)
@@ -127,8 +127,8 @@ Test Template<br></p>""",
         form = Form(composer)
         form.template_id = env["mail.template"]
         form.save()
-        self.assertFalse(form.template_id)
-        form.template_id = prod_tmpl
+        self.assertFalse(form.template_id)  # no template
+        form.template_id = partner_tmpl
         composer = form.save()
         expecting = self.partner_cc3 + self.partner_cc
         self.assertEqual(composer.partner_cc_ids, expecting)


### PR DESCRIPTION
### Note
- Took over this PR: `https://github.com/OCA/social/pull/1428`

- Took this chance to
    - Fix `https://github.com/OCA/social/issues/1263`
       - it was fixed in `https://github.com/OCA/social/pull/1309`
       - But there is a case, described in `https://github.com/OCA/social/pull/1310#issuecomment-2186838432` , which was not covered.
    - Backport from `17.0`: using `res.partner `instead `product.template` in test. Otherwise, tests cannot run because model product.template is not in environment.

- Forward these commits to 17.0 in: https://github.com/trisdoan/social/pull/27
- Backport to 15.0: **WIP**

### Result

In 16.0 
[mail_composer_cc_bcc_16.webm](https://github.com/user-attachments/assets/94096617-8331-4427-9364-ad5098ec63d9)
